### PR TITLE
[ fix ] asynchronously write to streams

### DIFF
--- a/src/System/UV/Stream.idr
+++ b/src/System/UV/Stream.idr
@@ -60,8 +60,8 @@ parameters {auto l : UVLoop}
   export
   write : Ptr t -> (0 _ : PCast t Stream) => ByteString -> Async es ()
   write str b =
-    use1 (fromByteString b) $ \cs =>
-      uv $ uv_write str cs (cast b.size) (\_,_ => pure ())
+    use1 (fromByteString b) $ \cs => uvAsync $ \cb =>
+      uv_write str cs (cast b.size) (\_,_ => cb $ Succeeded ())
 
   export
   listen :


### PR DESCRIPTION
This fixes a serious concurrency bug in `Stream.write`: So far, this was run without waiting for the write to finish. As can be imagined, with several writes being run in quick succession, all hell broke loose.